### PR TITLE
Use base URL from config

### DIFF
--- a/AccountService/src/main/java/org/mybatis/jpetstore/http/HttpFacade.java
+++ b/AccountService/src/main/java/org/mybatis/jpetstore/http/HttpFacade.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.beans.factory.annotation.Value;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
@@ -17,10 +18,11 @@ public class HttpFacade {
     @Autowired
     RestTemplate restTemplate;
 
-    private static final String CATALOG_SERVICE_URL = "http://localhost:8080/catalog";
+    @Value("${gateway.base-url}")
+    private String gatewayBaseUrl;
 
     public List<Product> getProductListByCategory(String categoryId) {
-        String url = CATALOG_SERVICE_URL + "/get/productList?catalogId=" + categoryId;
+        String url = gatewayBaseUrl + "/catalog/get/productList?catalogId=" + categoryId;
 
         ResponseEntity<Product[]> responseEntity = restTemplate.postForEntity(url, null, Product[].class);
         Product[] responses = responseEntity.getBody();

--- a/AccountService/src/main/resources/application.yml
+++ b/AccountService/src/main/resources/application.yml
@@ -27,3 +27,8 @@ spring:
 mybatis:
   type-aliases-package: org.mybatis.jpetstore.domain
   mapper-locations: classpath:mapperXML/*.xml
+
+gateway:
+  base-url: http://localhost:8080
+kafka:
+  bootstrap-servers: localhost:9092

--- a/CartService/src/main/java/org/mybatis/jpetstore/HttpRequest/HttpGetRequest.java
+++ b/CartService/src/main/java/org/mybatis/jpetstore/HttpRequest/HttpGetRequest.java
@@ -2,19 +2,25 @@ package org.mybatis.jpetstore.HttpRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.mybatis.jpetstore.domain.Item;
-
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+@Service
 public class HttpGetRequest {
-    public static Item getItemFromCatalogService(String itemId) {
+
+    @Value("${gateway.base-url}")
+    private String gatewayBaseUrl;
+
+    public Item getItemFromCatalogService(String itemId) {
         // TODO : 배포시 해당 URL로 변경
         try {
             // url 설정
-            URL url = new URL(String.format("http://localhost:8080/catalog/getItem?itemId=%s",itemId));
+            URL url = new URL(String.format("%s/catalog/getItem?itemId=%s", gatewayBaseUrl, itemId));
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             // 요청 방식 설정 (GET)
             connection.setRequestMethod("GET");
@@ -48,11 +54,11 @@ public class HttpGetRequest {
     }
 
 
-    public static Boolean isItemInStockFromCatalogService(String itemId) {
+    public Boolean isItemInStockFromCatalogService(String itemId) {
         // TODO : 배포시 해당 URL로 변경
         try {
             // url 설정
-            URL url = new URL(String.format("http://localhost:8080/catalog/isItemInStock?itemId=%s",itemId));
+            URL url = new URL(String.format("%s/catalog/isItemInStock?itemId=%s", gatewayBaseUrl, itemId));
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             // 요청 방식 설정 (GET)
             connection.setRequestMethod("GET");

--- a/CartService/src/main/java/org/mybatis/jpetstore/repository/CatalogRepository.java
+++ b/CartService/src/main/java/org/mybatis/jpetstore/repository/CatalogRepository.java
@@ -2,6 +2,7 @@ package org.mybatis.jpetstore.repository;
 
 import org.mybatis.jpetstore.HttpRequest.HttpGetRequest;
 import org.mybatis.jpetstore.domain.Item;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -10,6 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class CatalogRepository {
 
+    @Autowired
+    private HttpGetRequest httpGetRequest;
+
     /**
      * 지정한 ID의 상품을 조회합니다.
      *
@@ -17,7 +21,7 @@ public class CatalogRepository {
      * @return 상품 정보
      */
     public Item findItem(String itemId) {
-        return HttpGetRequest.getItemFromCatalogService(itemId);
+        return httpGetRequest.getItemFromCatalogService(itemId);
     }
 
     /**
@@ -27,7 +31,7 @@ public class CatalogRepository {
      * @return 재고 존재 여부
      */
     public boolean isItemInStock(String itemId) {
-        Boolean result = HttpGetRequest.isItemInStockFromCatalogService(itemId);
+        Boolean result = httpGetRequest.isItemInStockFromCatalogService(itemId);
         return Boolean.TRUE.equals(result);
     }
 }

--- a/CartService/src/main/resources/application.yml
+++ b/CartService/src/main/resources/application.yml
@@ -27,3 +27,8 @@ spring:
 mybatis:
   type-aliases-package: org.mybatis.jpetstore.domain
   mapper-locations: classpath:mapperXML/*.xml
+
+gateway:
+  base-url: http://localhost:8080
+kafka:
+  bootstrap-servers: localhost:9092

--- a/CatalogService/src/main/java/org/mybatis/jpetstore/kafka/KafkaConsumerConfig.java
+++ b/CatalogService/src/main/java/org/mybatis/jpetstore/kafka/KafkaConsumerConfig.java
@@ -10,6 +10,7 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,10 +19,13 @@ import java.util.Map;
 @EnableKafka
 public class KafkaConsumerConfig {
 
+    @Value("${kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
         Map<String, Object> config = new HashMap<>();
-        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(ConsumerConfig.GROUP_ID_CONFIG, "group_1");
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);

--- a/CatalogService/src/main/resources/application.yml
+++ b/CatalogService/src/main/resources/application.yml
@@ -27,3 +27,8 @@ spring:
 mybatis:
   type-aliases-package: org.mybatis.jpetstore.domain
   mapper-locations: classpath:mapperXML/*.xml
+
+gateway:
+  base-url: http://localhost:8080
+kafka:
+  bootstrap-servers: localhost:9092

--- a/OrderService/src/main/java/org/mybatis/jpetstore/controller/OrderController.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/controller/OrderController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.beans.factory.annotation.Value;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -19,7 +20,8 @@ import java.util.List;
 @Controller
 @RequestMapping("/")
 public class OrderController {
-    private static final String REDIRECT_BASE_URL="http://localhost:8080";
+    @Value("${gateway.base-url}")
+    private String redirectBaseUrl;
 
     @Autowired
     OrderService orderService;
@@ -30,7 +32,7 @@ public class OrderController {
         if (account == null) {
             String msg = "You must sign on before attempting to check out.  Please sign on and try checking out again.";
             redirect.addAttribute("msg", msg);
-            return "redirect:" + REDIRECT_BASE_URL + "/account/signonForm";
+            return "redirect:" + redirectBaseUrl + "/account/signonForm";
         }
         List<Order> orderList = orderService.getOrdersByUsername(account.getUsername());
         request.setAttribute("orderList", orderList);
@@ -44,7 +46,7 @@ public class OrderController {
         if (account == null) {
             String msg = "You must sign on before attempting to check out.  Please sign on and try checking out again.";
             redirect.addAttribute("msg", msg);
-            return "redirect:" + REDIRECT_BASE_URL + "/account/signonForm";
+            return "redirect:" + redirectBaseUrl + "/account/signonForm";
         }
         else if (cart != null) {
             Order order = orderService.createOrder(account, cart);
@@ -85,7 +87,7 @@ public class OrderController {
         if (account == null) {
             String msg = "You must sign on before attempting to check out.  Please sign on and try checking out again.";
             redirect.addAttribute("msg", msg);
-            return "redirect:" + REDIRECT_BASE_URL + "/account/signonForm";
+            return "redirect:" + redirectBaseUrl + "/account/signonForm";
         }
         Order order = orderService.getOrder(orderId);
         if (account.getUsername().equals(order.getUsername())) {

--- a/OrderService/src/main/java/org/mybatis/jpetstore/http/HttpFacade.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/http/HttpFacade.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,13 +18,14 @@ import java.util.stream.Collectors;
 public class HttpFacade {
     @Autowired
     RestTemplate restTemplate;
-    private static final String CATALOG_SERVICE_URL = "http://localhost:8080/catalog";
+    @Value("${gateway.base-url}")
+    private String gatewayBaseUrl;
 
     public boolean updateInventoryQuantity(Map<String, Object> param, Integer orderId) {
 
         String quantityString = param.values().stream().map(String::valueOf).collect(Collectors.joining(","));
 
-        String url = CATALOG_SERVICE_URL + "/updateQuantity?itemId=" + String.join(",", param.keySet()) + "&increment=" + quantityString + "&orderId=" + orderId;
+        String url = gatewayBaseUrl + "/catalog/updateQuantity?itemId=" + String.join(",", param.keySet()) + "&increment=" + quantityString + "&orderId=" + orderId;
 
         ResponseEntity<Boolean> responseEntity = restTemplate.getForEntity(url, Boolean.class);
         Boolean responses = responseEntity.getBody();
@@ -32,13 +34,13 @@ public class HttpFacade {
     }
 
     public boolean isInventoryUpdateCommitSuccess(Integer orderId){
-        String url = CATALOG_SERVICE_URL + "/isInventoryUpdated?orderId=" + orderId;
+        String url = gatewayBaseUrl + "/catalog/isInventoryUpdated?orderId=" + orderId;
         ResponseEntity<Boolean> responseEntity = restTemplate.getForEntity(url,Boolean.class);
         return Boolean.TRUE.equals(responseEntity.getBody());
     }
 
     public Item getItem(String itemId) {
-        String url = CATALOG_SERVICE_URL + "/getItem?itemId=" + itemId;
+        String url = gatewayBaseUrl + "/catalog/getItem?itemId=" + itemId;
 
         ResponseEntity<Item> responseEntity = restTemplate.getForEntity(url, Item.class);
         Item response = responseEntity.getBody();
@@ -46,7 +48,7 @@ public class HttpFacade {
     }
 
     public int getInventoryQuantity(String itemId) {
-        String url = CATALOG_SERVICE_URL + "/getQuantity?itemId=" + itemId;
+        String url = gatewayBaseUrl + "/catalog/getQuantity?itemId=" + itemId;
 
         ResponseEntity<Integer> responseEntity = restTemplate.getForEntity(url, Integer.class);
         int response = responseEntity.getBody();

--- a/OrderService/src/main/java/org/mybatis/jpetstore/kafka/KafkaProducerConfig.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/kafka/KafkaProducerConfig.java
@@ -8,17 +8,20 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
 public class KafkaProducerConfig {
+    @Value("${kafka.bootstrap-servers}")
+    private String bootstrapServers;
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
 
         Map<String, Object> config = new HashMap<>();
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
 

--- a/OrderService/src/main/resources/application.yml
+++ b/OrderService/src/main/resources/application.yml
@@ -27,3 +27,8 @@ spring:
 mybatis:
   type-aliases-package: org.mybatis.jpetstore.domain
   mapper-locations: classpath:mapperXML/*.xml
+
+gateway:
+  base-url: http://localhost:8080
+kafka:
+  bootstrap-servers: localhost:9092


### PR DESCRIPTION
## Summary
- add `gateway.base-url` and `kafka.bootstrap-servers` properties
- inject configurable URLs in services and controller
- update Catalog and Order kafka configs
- make CartService HTTP client a bean using injected URL

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68739f65c4c88324a82fe75ee4f47c43