### PR TITLE
Add Dockerfiles and compose for services

### DIFF
--- a/AccountService/Dockerfile
+++ b/AccountService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8.4-jdk21 AS build
+WORKDIR /workspace
+COPY . .
+RUN ./gradlew :AccountService:bootWar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/AccountService/build/libs/*.war app.war
+EXPOSE 8081
+ENTRYPOINT ["java","-jar","app.war"]

--- a/CartService/Dockerfile
+++ b/CartService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8.4-jdk21 AS build
+WORKDIR /workspace
+COPY . .
+RUN ./gradlew :CartService:bootWar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/CartService/build/libs/*.war app.war
+EXPOSE 8082
+ENTRYPOINT ["java","-jar","app.war"]

--- a/CatalogService/Dockerfile
+++ b/CatalogService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8.4-jdk21 AS build
+WORKDIR /workspace
+COPY . .
+RUN ./gradlew :CatalogService:bootWar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/CatalogService/build/libs/*.war app.war
+EXPOSE 8083
+ENTRYPOINT ["java","-jar","app.war"]

--- a/OrderService/Dockerfile
+++ b/OrderService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8.4-jdk21 AS build
+WORKDIR /workspace
+COPY . .
+RUN ./gradlew :OrderService:bootWar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/OrderService/build/libs/*.war app.war
+EXPOSE 8084
+ENTRYPOINT ["java","-jar","app.war"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,34 @@ services:
       - "80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
+
+  account-service:
+    build:
+      context: ..
+      dockerfile: AccountService/Dockerfile
+    ports:
+      - "8081:8081"
+
+  cart-service:
+    build:
+      context: ..
+      dockerfile: CartService/Dockerfile
+    ports:
+      - "8082:8082"
+
+  catalog-service:
+    build:
+      context: ..
+      dockerfile: CatalogService/Dockerfile
+    ports:
+      - "8083:8083"
+
+  order-service:
+    build:
+      context: ..
+      dockerfile: OrderService/Dockerfile
+    ports:
+      - "8084:8084"
 #    # Linux에서 host.docker.internal 사용을 위해:
 #    extra_hosts:
 #      - "host.docker.internal:host-gateway"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,7 +20,7 @@ http {
 
         # /account/* → 로컬 8081
         location /account/ {
-            proxy_pass         http://host.docker.internal:8081/;
+            proxy_pass         http://account-service:8081/;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -28,7 +28,7 @@ http {
 
         # /cart/* → 로컬 8082
         location /cart/ {
-            proxy_pass         http://host.docker.internal:8082/;
+            proxy_pass         http://cart-service:8082/;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -36,7 +36,7 @@ http {
 
         # /catalog/* → 로컬 8083
         location /catalog/ {
-            proxy_pass         http://host.docker.internal:8083/;
+            proxy_pass         http://catalog-service:8083/;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -44,7 +44,7 @@ http {
 
         # /order/* → 로컬 8084
         location /order/ {
-            proxy_pass         http://host.docker.internal:8084/;
+            proxy_pass         http://order-service:8084/;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- add Dockerfiles for Account, Cart, Catalog and Order services
- route nginx to each service container
- configure docker-compose to build each service image

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6877c3faca5c83248663b6ddbfed2e8f